### PR TITLE
Fix issue with onboarding not showing when WooCommerce is active

### DIFF
--- a/includes/InstallChecker.php
+++ b/includes/InstallChecker.php
@@ -95,19 +95,24 @@ class InstallChecker {
 	 * @return \WP_Post
 	 */
 	protected function getOldestPost() {
-		$query = new \WP_Query(
-			[
-				'post_type'           => [ 'post', 'page' ],
-				'post_status'         => 'any',
-				'orderby'             => 'ID',
-				'order'               => 'ASC',
-				'posts_per_page'      => 1,
-				'ignore_sticky_posts' => true,
-				'no_found_rows'       => true,
-				'cache_results'       => false,
-				'suppress_filters'    => true,
-			]
-		);
+
+		$args = [
+			'post_type'           => [ 'post', 'page' ],
+			'post_status'         => 'any',
+			'orderby'             => 'ID',
+			'order'               => 'ASC',
+			'posts_per_page'      => 1,
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'cache_results'       => false,
+			'suppress_filters'    => true,
+		];
+
+		if ( WooCommerce::isWooCommerce() ) {
+			$args['post__not_in'] = WooCommerce::getAllPageIds();
+		}
+
+		$query = new \WP_Query( $args );
 
 		return $query->post;
 	}
@@ -118,19 +123,24 @@ class InstallChecker {
 	 * @return \WP_Post
 	 */
 	protected function getNewestPost() {
-		$query = new \WP_Query(
-			[
-				'post_type'           => [ 'post', 'page' ],
-				'post_status'         => 'any',
-				'orderby'             => 'ID',
-				'order'               => 'DESC',
-				'posts_per_page'      => 1,
-				'ignore_sticky_posts' => true,
-				'no_found_rows'       => true,
-				'cache_results'       => false,
-				'suppress_filters'    => true,
-			]
-		);
+
+		$args = [
+			'post_type'           => [ 'post', 'page' ],
+			'post_status'         => 'any',
+			'orderby'             => 'ID',
+			'order'               => 'DESC',
+			'posts_per_page'      => 1,
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'cache_results'       => false,
+			'suppress_filters'    => true,
+		];
+
+		if ( WooCommerce::isWooCommerce() ) {
+			$args['post__not_in'] = WooCommerce::getAllPageIds();
+		}
+
+		$query = new \WP_Query( $args );
 
 		return $query->post;
 	}

--- a/includes/WooCommerce.php
+++ b/includes/WooCommerce.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\InstallChecker;
+
+class WooCommerce {
+
+	/**
+	 * Check if WooCommerce is installed and active.
+	 *
+	 * @return bool
+	 */
+	public static function isWooCommerce() {
+		return class_exists( 'WooCommerce' );
+	}
+
+	/**
+	 * Get all WooCommerce page IDs.
+	 *
+	 * @return int[]
+	 */
+	public static function getAllPageIds() {
+		return [
+			wc_get_page_id( 'shop' ),
+			wc_get_page_id( 'cart' ),
+			wc_get_page_id( 'checkout' ),
+			wc_get_page_id( 'myaccount' ),
+			wc_get_page_id( 'refund_returns' ),
+		];
+	}
+
+}


### PR DESCRIPTION
As it stands, onboarding isn't being triggered when WooCommerce is active. The reason is that WooCommerce creates a number of pages automatically when it is first activated. Since all the initial sites created on an e-commerce hosting account install WooCommerce automatically, these additional pages were causing the `isFreshInstall` check to fail and preventing onboarding from showing.

This PR updates things so that If WooCommerce is active, we ignore the pages that Woo sets up when determining which posts to use in the `isFreshInstall` check.