### PR TITLE
Do not check `isFreshInstallation` until `plugins_loaded`

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -26,7 +26,7 @@ if ( function_exists( 'add_action' ) ) {
 				)
 			);
 
-			add_action('plugins_loaded', function() use ($container) {
+			add_action( 'plugins_loaded', function() use ( $container ) {
 				$container->set(
 					'isFreshInstallation',
 					$container->computed(

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -26,14 +26,16 @@ if ( function_exists( 'add_action' ) ) {
 				)
 			);
 
-			$container->set(
-				'isFreshInstallation',
-				$container->computed(
-					function ( Container $container ) {
-						return $container->get( 'installChecker' )->isFreshInstallation();
-					}
-				)
-			);
+			add_action('plugins_loaded', function() use ($container) {
+				$container->set(
+					'isFreshInstallation',
+					$container->computed(
+						function ( Container $container ) {
+							return $container->get( 'installChecker' )->isFreshInstallation();
+						}
+					)
+				);
+			});
 
 		},
 		0


### PR DESCRIPTION
## Proposed changes

I see the following warning after activating.

> Notice: Function WP_User_Query::query was called incorrectly. User queries should not be run before the plugins_loaded hook. Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 6.1.1.) in /var/www/html/wp-includes/functions.php on line 6085 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-admin/includes/misc.php on line 1438 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-includes/functions.php on line 7108 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-admin/admin-header.php on line 9 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-includes/option.php on line 1692 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-includes/functions.php:6085) in /var/www/html/wp-includes/option.php on line 1693

Due to [InstallChecker::isFreshInstallation()](https://github.com/newfold-labs/wp-module-install-checker/blob/9d43e916b8c4e752b45c868b41340b84bcb686a6/includes/InstallChecker.php#L13) calling [::getOldestUser()](https://github.com/newfold-labs/wp-module-install-checker/blob/9d43e916b8c4e752b45c868b41340b84bcb686a6/includes/InstallChecker.php#L59) which uses `WP_User_Query`.

https://github.com/WordPress/WordPress/blob/6.6.2/wp-includes/class-wp-user-query.php#L785-L795

This fix wraps `bootstrap.php`'s [$container->set( 'isFreshInstallation'...](https://github.com/newfold-labs/wp-module-install-checker/blob/9d43e916b8c4e752b45c868b41340b84bcb686a6/bootstrap.php#L29-L36) in a function which runs on the `plugins_loaded` action.

Fixes #2 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
